### PR TITLE
Use local rotation tween with async completion

### DIFF
--- a/Assets/Scripts/View/Cards/CardView.cs
+++ b/Assets/Scripts/View/Cards/CardView.cs
@@ -181,10 +181,14 @@ namespace CardWar.Gameplay.Cards
 
         public async UniTask FlipToFront(CardData data)
         {
-            await transform.DORotateY(90f, 0.15f);
+            await transform
+                .DOLocalRotate(new Vector3(0f, 90f, 0f), 0.15f)
+                .AsyncWaitForCompletion();
             Setup(data);
             ShowFrontFace();
-            await transform.DORotateY(0f, 0.15f);
+            await transform
+                .DOLocalRotate(Vector3.zero, 0.15f)
+                .AsyncWaitForCompletion();
         }
 
         public async UniTask MoveToPosition(Vector3 target)


### PR DESCRIPTION
## Summary
- Switch CardView flip to use DOLocalRotate instead of DORotateY
- Await tween completion with AsyncWaitForCompletion

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af6c28dea8832cb0d9814b9a80a243