### PR TITLE
Use DOTween async helper in MoveToPosition

### DIFF
--- a/Assets/Scripts/View/Cards/CardView.cs
+++ b/Assets/Scripts/View/Cards/CardView.cs
@@ -193,7 +193,9 @@ namespace CardWar.Gameplay.Cards
 
         public async UniTask MoveToPosition(Vector3 target)
         {
-            await transform.DOMove(target, 0.5f).SetEase(Ease.OutQuad);
+            await transform.DOMove(target, 0.5f)
+                .SetEase(Ease.OutQuad)
+                .AsyncWaitForCompletion();
         }
 
         public void ShowWinPile(int cardCount)


### PR DESCRIPTION
## Summary
- chain AsyncWaitForCompletion onto DOMove tween in `CardView.MoveToPosition`
- verified no other awaited DOTween tweens lack an async helper

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6d08605c832cb2a0e81742cf7090